### PR TITLE
Fix loses of input formatting, close #47 (#49)

### DIFF
--- a/rules/src/main/scala/fix/Sortimports.scala
+++ b/rules/src/main/scala/fix/Sortimports.scala
@@ -98,7 +98,7 @@ class SortImports(config: SortImportsConfig) extends SyntacticRule("SortImports"
           }.fold(acc) {
             case (_, imports) =>
               val strImports = imports.map { imp =>
-                comments.get(imp).fold(imp.syntax)(comment => s"${imp.syntax} ${comment.syntax}")
+                comments.get(imp).fold(s"$imp")(comment => s"$imp $comment")
               }.toSeq
 
               acc :+ (strImports.init :+ (strImports.last + '\n'))


### PR DESCRIPTION
Using 'syntax' instead of 'toString' loss input formatting.